### PR TITLE
Fix deprecation warnings in HA 2022.5 and 2022.6

### DIFF
--- a/custom_components/mlgw/__init__.py
+++ b/custom_components/mlgw/__init__.py
@@ -1,5 +1,6 @@
 """The MasterLink Gateway integration."""
 import asyncio
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ServiceDataType
 from .gateway import create_mlgw_gateway, create_mlgw_gateway_with_configuration_data
 from .media_player import BeoSpeaker
@@ -218,7 +219,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         config_entry_id=entry.entry_id,
         configuration_url=f"http://{host}",
     )
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(**device_info)
 
     for component in PLATFORMS:

--- a/custom_components/mlgw/config_flow.py
+++ b/custom_components/mlgw/config_flow.py
@@ -62,8 +62,8 @@ def host_valid(host):
 
 # Get the MLGW/BLGW Serial number from the integrated Jabber Client
 #
-# This code causes the MLGW to crash if called too many times. Given that it is called every time there is 
-# a zeroconf discovery (every few mins), after a week or so it causes the device to crash. So, we cache the 
+# This code causes the MLGW to crash if called too many times. Given that it is called every time there is
+# a zeroconf discovery (every few mins), after a week or so it causes the device to crash. So, we cache the
 # SN based on the host address.
 #
 # This is an undocumented feature of the MLGW. The Traffic looks like:
@@ -235,17 +235,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Async_Step_Zeroconf discovery info %s" % discovery_info)
 
         # if it's not a MLGW or BLGW device, then abort
-        if not discovery_info.get("name"):
+        if not discovery_info.name:
             return self.async_abort(reason="not_mlgw_device")
 
         if not (
-            discovery_info["name"].startswith("MLGW")
-            or discovery_info["name"].startswith("BLGW")
+            discovery_info.name.startswith("MLGW")
+            or discovery_info.name.startswith("BLGW")
         ):
             return self.async_abort(reason="not_mlgw_device")
 
         # Hostname is format: mlgw.local.
-        self.host = discovery_info["hostname"].rstrip(".")
+        self.host = discovery_info.hostname.rstrip(".")
         _LOGGER.debug("Async_Step_Zeroconf Hostname %s" % self.host)
 
         try:


### PR DESCRIPTION
Align code with Homeassistant >= 2022.5 to remove deprecation messages.
Verified on HA 2022.5.5 and HA 2022.6.0.dev

There are still warnings from blocking calls in event loop. They emanate from the use of time.sleep() in a couple of places. 